### PR TITLE
[ADD] Use relative paths instead of absolute paths

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`onTestResult matches the last snapshot for a failing test 1`] = `
 "
-/home/basie/foo/mobile/src/components/FlargleArgle/FlargleArgle.test.js:74:3:E:Expected mock function not to be called but it was called with: Array [] "
+src/components/FlargleArgle/FlargleArgle.test.js:74:3:E:Expected mock function not to be called but it was called with: Array [] "
 `;
 
 exports[`onTestResult matches the last snapshot for a passsing test 1`] = `
 "
-/foo/bar/wombat:::I:Flargle:Works as expected"
+foo/bar/wombat:::I:Flargle:Works as expected"
 `;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 class JestSimpleReporter {
   constructor (globalConfig, options) {
     this._globalConfig = globalConfig
@@ -28,15 +30,15 @@ class JestSimpleReporter {
               const loc = trace.substring(
                 trace.indexOf('(') + 1,
                 trace.indexOf(')') - 1
-              )
+              ).split(':')
 
-              console.log(`${firstNewline}${loc}:${translatedStatus}:${message}`)
+              console.log(`${firstNewline}${path.relative('./', loc[0])}:${loc.slice(-2).join(':')}:${translatedStatus}:${message}`)
             }
           })
           break
 
         case 'passed':
-          console.log(`${firstNewline}${testFilePath}:::${translatedStatus}:${ancestorTitles.join(' > ')}:${title}`)
+          console.log(`${firstNewline}${path.relative('./', testFilePath)}:::${translatedStatus}:${ancestorTitles.join(' > ')}:${title}`)
           break
       }
       if (this._first) this._first = false

--- a/index.test.js
+++ b/index.test.js
@@ -1,12 +1,25 @@
 import JestSimpleReporter from './'
 
 describe('onTestResult', () => {
-  const test = { path: 'foo' }
+  const test = {}
   const results = {
-    testFilePath: '/foo/bar/wombat',
+    testFilePath: 'foo/bar/wombat',
     testResults: [{
       ancestorTitles: [ 'Flargle' ],
-      failureMessages: [ 'Error: expect(jest.fn()).not.toHaveBeenCalled()\n\nExpected mock function not to be called but it was called with:\n  Array []\n    at Object.<anonymous> (/home/basie/foo/mobile/src/components/FlargleArgle/FlargleArgle.test.js:74:34)\n    at Object.asyncFn (/home/basie/foo/mobile/node_modules/jest-jasmine2/build/jasmine-async.js:68:30)\n    at resolve (/home/basie/foo/mobile/node_modules/jest-jasmine2/build/queueRunner.js:38:12)\n    at tryCallTwo (/home/basie/foo/mobile/node_modules/promise/lib/core.js:45:1)\n    at doResolve (/home/basie/foo/mobile/node_modules/promise/lib/core.js:200:9)\n    at new Promise (/home/basie/foo/mobile/node_modules/promise/lib/core.js:66:1)\n    at mapper (/home/basie/foo/mobile/node_modules/jest-jasmine2/build/queueRunner.js:31:21)\n    at Promise.resolve.then.el (/home/basie/foo/mobile/node_modules/p-map/index.js:42:16)\n    at tryCallOne (/home/basie/foo/mobile/node_modules/promise/lib/core.js:37:8)\n    at /home/basie/foo/mobile/node_modules/promise/lib/core.js:123:9' ],
+      failureMessages: [ `Error: expect(jest.fn()).not.toHaveBeenCalled()
+
+Expected mock function not to be called but it was called with:
+  Array []
+    at Object.<anonymous> (${__dirname}/src/components/FlargleArgle/FlargleArgle.test.js:74:34)
+    at Object.asyncFn (${__dirname}/node_modules/jest-jasmine2/build/jasmine-async.js:68:30)
+    at resolve (${__dirname}/node_modules/jest-jasmine2/build/queueRunner.js:38:12)
+    at tryCallTwo (${__dirname}/node_modules/promise/lib/core.js:45:1)
+    at doResolve (${__dirname}/node_modules/promise/lib/core.js:200:9)
+    at new Promise (${__dirname}/node_modules/promise/lib/core.js:66:1)
+    at mapper (${__dirname}/node_modules/jest-jasmine2/build/queueRunner.js:31:21)
+    at Promise.resolve.then.el (${__dirname}/node_modules/p-map/index.js:42:16)
+    at tryCallOne (${__dirname}/node_modules/promise/lib/core.js:37:8)
+    at ${__dirname}/node_modules/promise/lib/core.js:123:9` ],
       status: 'failed'
     }]
   }


### PR DESCRIPTION
Hello, I find absolute paths to be unwieldy in the quickfix window so here is a slight modification that reports relative paths instead.

Before:

    /home/basie/foo/mobile/src/components/FlargleArgle/FlargleArgle.test.js:52:1:E:<message>

Now (supposing we are in `/home/basie/foo/mobile/`):

    src/components/FlargleArgle/FlargleArgle.test.js:52:1:E:<message>